### PR TITLE
Update light.gd to make compatible with ikea light

### DIFF
--- a/app/content/entities/light/light.gd
+++ b/app/content/entities/light/light.gd
@@ -82,7 +82,7 @@ func _ready():
 			HomeApi.set_state(entity_id, "on", {"effect": option})
 		)
 
-	if stateInfo.has("attributes")&&stateInfo["attributes"].has("supported_color_modes")&&stateInfo["attributes"]["supported_color_modes"].has("rgb"):
+	if stateInfo.has("attributes")&&stateInfo["attributes"]["supported_color_modes"].has("hs")&&stateInfo["attributes"].has("supported_color_modes")&&stateInfo["attributes"]["supported_color_modes"].has("rgb"):
 		color_wheel_supported.value = true
 
 	await HomeApi.watch_state(entity_id, func(new_state):


### PR DESCRIPTION
I have add "stateInfo["attributes"]["supported_color_modes"].has("hs")" to make immersive home compatible with lights that use "- hs" color'mode.

Try to build the apk file, because i can't on my macbook air m3 and send it to me.